### PR TITLE
Handle empty requests for posts/puts/etc

### DIFF
--- a/src/Generators/ApiRouteGenerator.php
+++ b/src/Generators/ApiRouteGenerator.php
@@ -148,7 +148,7 @@ class ApiRouteGenerator extends AbstractGenerator
         if ($request) {
             $signature .= $signature ? ', ' : '';
             $signature .= "request: $request = {} as $request";
-        } elseif ($glumRequest) {
+        } elseif ($glumRequest !== null) {
             $request = $this->transformResponseToTypescriptType($glumRequest);
             $isOptional = $this->isEveryMemberOptional($request);
             $signature .= $signature ? ', ' : '';
@@ -169,10 +169,11 @@ class ApiRouteGenerator extends AbstractGenerator
         $path = Str::of($path)->startsWith('/') ? $path : "/$path";
         $call = "axios.$method$generic(`$path";
 
-        if ($request || $glumRequest) {
+        if ($request || $glumRequest !== null) {
             $call .= $method === 'get' ? '?${transformToQueryString(request)}`' : '`, request';
         } else {
-            $call .= '`';
+            // For GET/DELETE, close the template literal. For POST/PUT/PATCH, add empty body
+            $call .= in_array($method, ['get', 'delete']) ? '`' : '`, {}';
         }
 
         // Add precognitive support


### PR DESCRIPTION
Currently, if you create a POST request and don't explicitly define a request structure, puddleglum generates without anything in the "request" section, and thus sends headers in the request body. Bugbot always yells about this, which wastes our time and attention. Plus, AI *very often* gets around the mis-formed typescript controller by directly using axios in frontend controllers, which gives us a bunch of dead code in unused controllers. 

This change does two things: 
- If you don't define any request at all, puddleglum will put an empty object in the "request" section {}
- If you define an empty #GlumRequest([]), puddlegum will include "request" in the params of the method, but have it default to empty. 