### PR TITLE
Preserve root API controller files

### DIFF
--- a/src/Generators/ApiRouteGenerator.php
+++ b/src/Generators/ApiRouteGenerator.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use ReflectionClass;
+use ReflectionMethod;
 use ReflectionNamedType;
 
 class ApiRouteGenerator extends AbstractGenerator
@@ -239,11 +240,7 @@ TS;
 
         $controllerReflection = new ReflectionClass($controller);
         $method = $controllerReflection->getMethod($methodName);
-        $request = collect($method->getParameters())->first(
-            fn($parameter) => $parameter->getClass() &&
-                $parameter->getClass()->isSubclassOf(FormRequest::class),
-        );
-        $requestType = $request?->getType();
+        $requestType = self::formRequestType($method);
         $glumRequest = collect($method->getAttributes())->first(
             fn($attribute) => $attribute->getName() ===
                 'Calvient\Puddleglum\Attributes\GlumRequest',
@@ -294,5 +291,22 @@ TS;
                 ],
             )
             ->toArray();
+    }
+
+    private static function formRequestType(ReflectionMethod $method): ?ReflectionNamedType
+    {
+        foreach ($method->getParameters() as $parameter) {
+            $type = $parameter->getType();
+
+            if (! $type instanceof ReflectionNamedType || $type->isBuiltin()) {
+                continue;
+            }
+
+            if (is_a($type->getName(), FormRequest::class, true)) {
+                return $type;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/PuddleglumGenerator.php
+++ b/src/PuddleglumGenerator.php
@@ -89,7 +89,7 @@ class PuddleglumGenerator
                     $folder = $this->kebabifyPath($folder);
 
                     foreach ($contents as $file) {
-                        $generatedFiles[$filename . $folder . '/' . $file['classFilename']] = $file['contents'];
+                        $generatedFiles[$this->relativePath($filename, (string) $folder, $file['classFilename'])] = $file['contents'];
                     }
                 } else {
                     $generatedFiles[$filename] = TypeScriptFormatter::namespace(
@@ -228,10 +228,10 @@ TS;
 
         foreach ($files as $relativePath => $chunks) {
             $contents = TypeScriptFormatter::file(implode(PHP_EOL . PHP_EOL, $chunks));
-            $path = $this->output . '/' . $relativePath;
+            $path = $this->outputPath($relativePath);
 
             TypeScriptFormatter::writeFileIfChanged($path, $contents);
-            $expectedPaths[$path] = true;
+            $expectedPaths[realpath($path) ?: $path] = true;
         }
 
         $this->deleteStaleFiles($expectedPaths);
@@ -254,7 +254,9 @@ TS;
 
         /** @var SplFileInfo $file */
         foreach ($iterator as $file) {
-            if ($file->isFile() && ! isset($expectedPaths[$file->getPathname()])) {
+            $path = $file->getRealPath() ?: $file->getPathname();
+
+            if ($file->isFile() && ! isset($expectedPaths[$path])) {
                 unlink($file->getPathname());
             }
         }
@@ -287,6 +289,19 @@ TS;
         if (!file_exists($path)) {
             mkdir($path, 0755, true);
         }
+    }
+
+    private function outputPath(string $relativePath): string
+    {
+        return rtrim($this->output, '/\\') . DIRECTORY_SEPARATOR . $relativePath;
+    }
+
+    private function relativePath(string ...$parts): string
+    {
+        return collect($parts)
+            ->flatMap(fn(string $part) => explode('/', str_replace('\\', '/', $part)))
+            ->filter(fn(string $part) => $part !== '')
+            ->implode('/');
     }
 
     private function kebabifyPath(string $path): string

--- a/tests/Feature/GeneratePuddleglumTypesTest.php
+++ b/tests/Feature/GeneratePuddleglumTypesTest.php
@@ -74,6 +74,14 @@ class GeneratePuddleglumTypesTest extends TestCase
         $this->assertFileDoesNotExist($staleFile);
     }
 
+    public function test_generate_command_keeps_api_files_when_namespace_matches_generated_namespace_prefix(): void
+    {
+        $outputDirectory = $this->generateTypes(namespace: 'Glum');
+
+        $this->assertFileExists($outputDirectory . '/api/ProductController.ts');
+        $this->assertFileExists($outputDirectory . '/api/ProductControllerArchive.ts');
+    }
+
     public function test_generate_command_invokes_each_model_relation_once(): void
     {
         $this->generateTypes();
@@ -84,12 +92,12 @@ class GeneratePuddleglumTypesTest extends TestCase
         $this->assertSame(1, \App\Models\Product::$featuresRelationCalls);
     }
 
-    private function generateTypes(): string
+    private function generateTypes(string $namespace = 'Puddleglum'): string
     {
         $outputDirectory = $this->fixtureRoot . '/resources/ts/puddleglum';
 
         config()->set('puddleglum.output', $outputDirectory);
-        config()->set('puddleglum.namespace', 'Puddleglum');
+        config()->set('puddleglum.namespace', $namespace);
         config()->set('puddleglum.models_namespace', 'Models');
 
         chdir($this->fixtureRoot);


### PR DESCRIPTION
## Summary
- Normalize generated API relative paths so namespace prefixes like Glum do not produce api//Controller.ts paths
- Compare canonical paths during stale-file cleanup so just-written files are not deleted
- Replace deprecated FormRequest reflection lookup while reading API route metadata

## Tests
- composer test
- composer stan
- composer validate --strict --no-check-publish
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/calvient/codesmith/puddleglum/pr/9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785597664&installation_id=134754726&pr_number=9&repository=calvient%2Fpuddleglum&return_to=https%3A%2F%2Fgithub.com%2Fcalvient%2Fpuddleglum%2Fpull%2F9&signature=e7442247c36275af3d84007b1571665432bfbd23fa940346f2427620f1a5da9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->