### PR TITLE
Order generated API imports

### DIFF
--- a/src/Generators/ApiRouteGenerator.php
+++ b/src/Generators/ApiRouteGenerator.php
@@ -18,9 +18,9 @@ class ApiRouteGenerator extends AbstractGenerator
 
     protected string $fileImports = <<<'TS'
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import axios, { AxiosRequestConfig } from 'axios';
-import { Glum } from 'puddleglum';
-import { transformToQueryString, PaginatedResponse } from 'puddleglum/utils';
+import axios, {AxiosRequestConfig} from 'axios';
+import {Glum} from 'puddleglum';
+import {transformToQueryString, PaginatedResponse} from 'puddleglum/utils';
 TS;
 
     public function __construct(private ?Collection $routes = null)

--- a/src/Generators/ApiRouteGenerator.php
+++ b/src/Generators/ApiRouteGenerator.php
@@ -19,8 +19,8 @@ class ApiRouteGenerator extends AbstractGenerator
     protected string $fileImports = <<<'TS'
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import axios, { AxiosRequestConfig } from 'axios';
-import { transformToQueryString, PaginatedResponse } from 'puddleglum/utils';
 import { Glum } from 'puddleglum';
+import { transformToQueryString, PaginatedResponse } from 'puddleglum/utils';
 TS;
 
     public function __construct(private ?Collection $routes = null)

--- a/tests/Feature/GeneratePuddleglumTypesTest.php
+++ b/tests/Feature/GeneratePuddleglumTypesTest.php
@@ -49,6 +49,19 @@ class GeneratePuddleglumTypesTest extends TestCase
         $this->assertGeneratedTreeMatchesFixture($outputDirectory);
     }
 
+    public function test_generate_command_emits_lint_safe_api_import_order(): void
+    {
+        $outputDirectory = $this->generateTypes();
+        $contents = file_get_contents($outputDirectory . '/api/puddleglum/ProductController.ts');
+
+        $glumImport = strpos($contents, "import { Glum } from 'puddleglum';");
+        $utilsImport = strpos($contents, "import { transformToQueryString, PaginatedResponse } from 'puddleglum/utils';");
+
+        $this->assertNotFalse($glumImport);
+        $this->assertNotFalse($utilsImport);
+        $this->assertLessThan($utilsImport, $glumImport);
+    }
+
     public function test_generate_command_does_not_rewrite_unchanged_files(): void
     {
         $outputDirectory = $this->generateTypes();

--- a/tests/Feature/GeneratePuddleglumTypesTest.php
+++ b/tests/Feature/GeneratePuddleglumTypesTest.php
@@ -54,12 +54,19 @@ class GeneratePuddleglumTypesTest extends TestCase
         $outputDirectory = $this->generateTypes();
         $contents = file_get_contents($outputDirectory . '/api/puddleglum/ProductController.ts');
 
-        $glumImport = strpos($contents, "import { Glum } from 'puddleglum';");
-        $utilsImport = strpos($contents, "import { transformToQueryString, PaginatedResponse } from 'puddleglum/utils';");
-
-        $this->assertNotFalse($glumImport);
-        $this->assertNotFalse($utilsImport);
-        $this->assertLessThan($utilsImport, $glumImport);
+        $this->assertSame(
+            [
+                "import axios, {AxiosRequestConfig} from 'axios';",
+                "import {Glum} from 'puddleglum';",
+                "import {transformToQueryString, PaginatedResponse} from 'puddleglum/utils';",
+            ],
+            array_values(
+                array_filter(
+                    explode(PHP_EOL, $contents),
+                    fn(string $line) => str_starts_with($line, 'import '),
+                ),
+            ),
+        );
     }
 
     public function test_generate_command_does_not_rewrite_unchanged_files(): void

--- a/tests/Fixtures/Expected/puddleglum/api/puddleglum/ProductController.ts
+++ b/tests/Fixtures/Expected/puddleglum/api/puddleglum/ProductController.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import axios, { AxiosRequestConfig } from 'axios';
-import { Glum } from 'puddleglum';
-import { transformToQueryString, PaginatedResponse } from 'puddleglum/utils';
+import axios, {AxiosRequestConfig} from 'axios';
+import {Glum} from 'puddleglum';
+import {transformToQueryString, PaginatedResponse} from 'puddleglum/utils';
 
 export default class ProductController {
   static async index(

--- a/tests/Fixtures/Expected/puddleglum/api/puddleglum/ProductController.ts
+++ b/tests/Fixtures/Expected/puddleglum/api/puddleglum/ProductController.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import axios, { AxiosRequestConfig } from 'axios';
-import { transformToQueryString, PaginatedResponse } from 'puddleglum/utils';
 import { Glum } from 'puddleglum';
+import { transformToQueryString, PaginatedResponse } from 'puddleglum/utils';
 
 export default class ProductController {
   static async index(

--- a/tests/Fixtures/Expected/puddleglum/api/puddleglum/ProductControllerArchive.ts
+++ b/tests/Fixtures/Expected/puddleglum/api/puddleglum/ProductControllerArchive.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import axios, { AxiosRequestConfig } from 'axios';
-import { Glum } from 'puddleglum';
-import { transformToQueryString, PaginatedResponse } from 'puddleglum/utils';
+import axios, {AxiosRequestConfig} from 'axios';
+import {Glum} from 'puddleglum';
+import {transformToQueryString, PaginatedResponse} from 'puddleglum/utils';
 
 export default class ProductControllerArchive {
   static async index(

--- a/tests/Fixtures/Expected/puddleglum/api/puddleglum/ProductControllerArchive.ts
+++ b/tests/Fixtures/Expected/puddleglum/api/puddleglum/ProductControllerArchive.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import axios, { AxiosRequestConfig } from 'axios';
-import { transformToQueryString, PaginatedResponse } from 'puddleglum/utils';
 import { Glum } from 'puddleglum';
+import { transformToQueryString, PaginatedResponse } from 'puddleglum/utils';
 
 export default class ProductControllerArchive {
   static async index(


### PR DESCRIPTION
## Summary
- Put the generated puddleglum import before puddleglum/utils to satisfy import/order
- Emit named imports without spaces inside braces, e.g. {transformToQueryString, PaginatedResponse}
- Add a regression test for API import ordering and brace spacing
- Update API golden fixtures to match the lint-safe output

## Tests
- vendor/bin/phpunit --no-coverage --filter test_generate_command_emits_lint_safe_api_import_order
- composer test
- composer stan
- composer validate --strict --no-check-publish
- git diff --check